### PR TITLE
feat(chatForm): 채용 공고 생성 페이지 및 폼 컴포넌트 리팩토링

### DIFF
--- a/src/app/chatForm/page.tsx
+++ b/src/app/chatForm/page.tsx
@@ -1,11 +1,34 @@
-'use client'
+'use client';
 
-import formPage from "@/app/components/chatFormComponents/form";
+import FormPage from "@/app/components/chatFormComponents/form";
+import Link from 'next/link';
+import {ArrowLeft} from 'lucide-react';
 
-export default function ChatForm() {
+export default function ChatFormPage() {
     return (
-        <div>
-            {formPage()}
+        <div className="min-h-screen bg-background py-8">
+            <div className="container mx-auto px-6">
+                <div className="mb-6">
+                    <Link
+                        href="/"
+                        className="inline-flex items-center gap-2 text-foreground-muted hover:text-foreground transition-colors"
+                    >
+                        <ArrowLeft className="w-4 h-4" />
+                        홈으로 돌아가기
+                    </Link>
+                </div>
+
+                <div className="max-w-4xl mx-auto">
+                    <div className="text-center mb-8">
+                        <h1 className="text-h1 font-sans mb-2 text-foreground">채용 공고 생성</h1>
+                        <p className="text-body text-foreground-muted max-w-2xl mx-auto">
+                            AI 챗봇과 대화하여 완벽한 채용 공고를 만들어보세요.
+                            입력하신 정보를 바탕으로 전문적인 채용 공고를 자동으로 생성해드립니다.
+                        </p>
+                    </div>
+                    <FormPage />
+                </div>
+            </div>
         </div>
-    )
+    );
 }

--- a/src/app/components/chatFormComponents/InputTag.tsx
+++ b/src/app/components/chatFormComponents/InputTag.tsx
@@ -1,33 +1,46 @@
 import {InputType, TextAreaType} from "./types/inputType";
 
-export function InputTag({title,type,value,onChange,classMethod,id,name}:InputType) {
+export function InputTag({title, type, value, onChange, classMethod, id, name}: InputType) {
     return (
-        <div>
+        <div className="input-field-container">
             <label
                 htmlFor={id}
-                className="block mb-2">
+                className="input-label"
+            >
                 {title}
             </label>
             <input
                 type={type}
                 value={value}
                 onChange={onChange}
-                className={classMethod}
+                className={`input-field ${classMethod}`}
                 id={id}
-                name={name}/>
+                name={name}
+                placeholder={`${title}을(를) 입력해주세요`}
+            />
         </div>
     )
 }
 
-export function TextArea({value, onChange, classMethod, id, name, cols, rows}:TextAreaType){
+export function TextArea({title, value, onChange, classMethod, id, name, cols, rows}: TextAreaType){
     return (
-        <textarea
-            value={value}
-            onChange={onChange}
-            className={classMethod}
-            id={id}
-            name={name}
-            cols={cols}
-            rows={rows}></textarea>
+        <div className="input-field-container">
+            <label
+                htmlFor={id}
+                className="input-label"
+            >
+                {title}
+            </label>
+            <textarea
+                value={value}
+                onChange={onChange}
+                className={`textarea-field ${classMethod}`}
+                id={id}
+                name={name}
+                cols={cols}
+                rows={rows}
+                placeholder={`${title}에 대한 내용을 자세히 작성해주세요`}
+            />
+        </div>
     )
 }

--- a/src/app/components/chatFormComponents/css/fromStyle.css
+++ b/src/app/components/chatFormComponents/css/fromStyle.css
@@ -1,0 +1,397 @@
+/* 디자인 시스템 변수 활용 */
+.form-container {
+    max-width: 1000px;
+    margin: 0 auto;
+    background: oklch(var(--card));
+    border: 1px solid oklch(var(--border));
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    animation: fadeInUp 0.6s ease-out;
+}
+
+/* 폼 헤더 */
+.form-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2.5rem 2.5rem 1.5rem;
+    background: oklch(var(--background));
+    border-bottom: 1px solid oklch(var(--border));
+}
+
+.form-header-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    background: oklch(var(--foreground));
+    color: oklch(var(--background));
+    border-radius: var(--radius-lg);
+    flex-shrink: 0;
+}
+
+.form-title {
+    font-family: var(--font-sans);
+    font-size: var(--text-h1);
+    font-weight: 700;
+    color: oklch(var(--foreground));
+    margin: 0 0 0.5rem 0;
+}
+
+.form-description {
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    color: oklch(var(--foreground-muted-l) var(--foreground-muted-c) var(--foreground-muted-h));
+    margin: 0;
+    line-height: 1.6;
+}
+
+/* 폼 컨텐츠 */
+.form-content {
+    padding: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+}
+
+/* 섹션 스타일 - 더 명확한 구분 */
+.form-section {
+    display: flex;
+    flex-direction: column;
+    /*gap: 0.5rem;*/
+    padding: 2rem;
+    background: oklch(var(--background));
+    border: 1px solid oklch(var(--border));
+    border-radius: var(--radius-md);
+}
+
+.section-header {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid oklch(var(--border));
+}
+
+.section-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-h2);
+    font-weight: 600;
+    color: oklch(var(--foreground));
+    margin: 0 0 0.75rem 0;
+}
+
+.section-description {
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    color: oklch(var(--foreground-muted-l) var(--foreground-muted-c) var(--foreground-muted-h));
+    margin: 0;
+    line-height: 1.6;
+}
+
+/* 필드 컨테이너 - 각 필드를 구분 */
+.form-fields-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-field-item {
+    display: flex;
+    flex-direction: column;
+}
+
+/* 필드 간 구분선 */
+.field-divider {
+    width: 100%;
+    height: 1px;
+    background: oklch(var(--border));
+    margin: 2rem 0;
+    opacity: 0.5;
+}
+
+/* 입력 필드 컨테이너 - 라벨과 인풋 사이 간격 */
+.input-field-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    /*padding: 1.5rem 0;*/
+}
+
+/* 라벨 스타일 */
+.input-label {
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    font-weight: 600;
+    color: oklch(var(--foreground)) !important;
+    margin: 0;
+}
+
+/* 입력 필드 스타일 */
+.input-field {
+    width: 100%;
+    padding: 1rem 1.25rem;
+    border: 1px solid oklch(var(--border));
+    border-radius: var(--radius-md);
+    background: oklch(var(--card)) !important;
+    color: oklch(var(--foreground)) !important;
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    transition: all 0.2s ease-in-out;
+    min-height: 48px;
+}
+
+.input-field::placeholder {
+    color: oklch(var(--foreground-muted-l) var(--foreground-muted-c) var(--foreground-muted-h));
+    opacity: 0.7;
+}
+
+.input-field:focus {
+    outline: none;
+    border-color: oklch(var(--foreground)) !important;
+    box-shadow: 0 0 0 3px oklch(var(--foreground) / 0.1);
+    background: oklch(var(--background)) !important;
+}
+
+.input-field:hover {
+    border-color: oklch(var(--border) / 0.7);
+    background: oklch(var(--background));
+}
+
+/* 텍스트에리어 전체 컨테이너 */
+.textarea-full-container {
+    width: 100%;
+    padding: 1.5rem 0;
+}
+
+/* 텍스트에리어 스타일 - 라벨 없이 꽉 채움 */
+.textarea-field-full {
+    width: 100%;
+    padding: 1.25rem 1.5rem;
+    border: 1px solid oklch(var(--border));
+    border-radius: var(--radius-md);
+    background: oklch(var(--card)) !important;
+    color: oklch(var(--foreground)) !important;
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    resize: vertical;
+    min-height: 160px;
+    transition: all 0.2s ease-in-out;
+    line-height: 1.6;
+}
+
+.textarea-field-full::placeholder {
+    color: oklch(var(--foreground-muted-l) var(--foreground-muted-c) var(--foreground-muted-h));
+    opacity: 0.7;
+}
+
+.textarea-field-full:focus {
+    outline: none;
+    border-color: oklch(var(--foreground)) !important;
+    box-shadow: 0 0 0 3px oklch(var(--foreground) / 0.1);
+    background: oklch(var(--background)) !important;
+}
+
+.textarea-field-full:hover {
+    border-color: oklch(var(--border) / 0.7);
+    background: oklch(var(--background));
+}
+
+/* 버튼 영역 - 더 명확한 구분과 색상 */
+.form-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+    margin-top: 2rem;
+    padding: 2.5rem;
+    background: oklch(var(--card));
+    border-top: 1px solid oklch(var(--border));
+    border-radius: var(--radius-md);
+}
+
+/* 버튼 기본 스타일 */
+.btn-submit,
+.btn-reset {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 2.5rem;
+    border-radius: var(--radius-md);
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.2s ease-in-out;
+    cursor: pointer;
+    border: 1px solid transparent;
+    min-height: 52px;
+    min-width: 180px;
+    justify-content: center;
+}
+
+/* 제출 버튼 - 파란색 (강제 적용) */
+.btn-submit {
+    background: #3b82f6 !important;
+    color: #ffffff !important;
+    border-color: #3b82f6 !important;
+}
+
+.btn-submit:hover {
+    background: #2563eb !important;
+    border-color: #2563eb !important;
+    color: #ffffff !important;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3) !important;
+}
+
+.btn-submit:active {
+    transform: translateY(0);
+}
+
+/* 초기화 버튼 - 회색 (강제 적용) */
+.btn-reset {
+    background: #6b7280 !important;
+    color: #ffffff !important;
+    border-color: #6b7280 !important;
+}
+
+.btn-reset:hover {
+    background: #4b5563 !important;
+    border-color: #4b5563 !important;
+    color: #ffffff !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3) !important;
+}
+
+/* 애니메이션 */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* 반응형 디자인 - 태블릿 */
+@media (max-width: 1024px) {
+    .form-container {
+        max-width: 800px;
+    }
+}
+
+/* 반응형 디자인 - 모바일 */
+@media (max-width: 768px) {
+    .form-container {
+        margin: 1rem;
+        border-radius: var(--radius-md);
+    }
+
+    .form-header {
+        padding: 2rem 2rem 1rem;
+        flex-direction: column;
+        text-align: center;
+        gap: 1.5rem;
+    }
+
+    .form-content {
+        padding: 2rem;
+        gap: 2rem;
+    }
+
+    .form-section {
+        padding: 1.5rem;
+        gap: 1.5rem;
+    }
+
+    .form-actions {
+        flex-direction: column-reverse;
+        gap: 1rem;
+        padding: 2rem;
+    }
+
+    .btn-submit,
+    .btn-reset {
+        width: 100%;
+        min-width: auto;
+    }
+}
+
+@media (max-width: 480px) {
+    .form-header {
+        padding: 1.5rem;
+    }
+
+    .form-content {
+        padding: 1.5rem;
+    }
+
+    .form-section {
+        padding: 1rem;
+    }
+
+    .form-header-icon {
+        width: 3rem;
+        height: 3rem;
+    }
+
+    .input-field,
+    .textarea-field-full {
+        padding: 0.875rem 1rem;
+    }
+
+    .form-actions {
+        padding: 1.5rem;
+    }
+}
+
+/* 포커스 상태 접근성 개선 */
+.input-field:focus-visible,
+.textarea-field-full:focus-visible,
+.btn-submit:focus-visible,
+.btn-reset:focus-visible {
+    outline: 2px solid oklch(var(--foreground));
+    outline-offset: 2px;
+}
+
+/* 로딩 상태 */
+.form-loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.form-loading .input-field,
+.form-loading .textarea-field-full {
+    background: oklch(var(--card));
+    color: oklch(var(--foreground-muted-l) var(--foreground-muted-c) var(--foreground-muted-h));
+}
+
+/* 성공/에러 상태 */
+.input-field.success,
+.textarea-field-full.success {
+    border-color: #10b981 !important;
+    box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.1) !important;
+}
+
+.input-field.error,
+.textarea-field-full.error {
+    border-color: #ef4444 !important;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1) !important;
+}
+
+.error-message {
+    color: #ef4444 !important;
+    font-size: var(--text-caption);
+    margin-top: 0.5rem;
+}
+
+.success-message {
+    color: #10b981 !important;
+    font-size: var(--text-caption);
+    margin-top: 0.5rem;
+}

--- a/src/app/components/chatFormComponents/form.tsx
+++ b/src/app/components/chatFormComponents/form.tsx
@@ -1,30 +1,189 @@
 'use client';
 
-import {InputTag, TextArea} from './InputTag';
+import './css/fromStyle.css'; // CSS 임포트 추가
+import {InputTag} from './InputTag';
 import {useFormState} from './formState/useFormState';
+import {BotMessageSquare, Briefcase, Building, CheckCircle, Gift, Mail, RotateCcw, Send, User} from 'lucide-react';
 
 export default function FormPage(){
     const {inputValue, setInputValue, textAreaValue, setTextAreaValue} = useFormState();
 
+    // 섹션별로 분리하여 가독성 개선
+    const basicInfoFields = [
+        { title: '채용 포지션', id: 'position', name: 'position', icon: <Briefcase className="w-4 h-4" /> },
+        { title: '회사 소개', id: 'company', name: 'company', icon: <Building className="w-4 h-4" /> },
+    ];
+
+    const jobInfoFields = [
+        { title: '주요 업무', id: 'duties', name: 'duties', icon: <User className="w-4 h-4" /> },
+        { title: '자격 요건', id: 'requirements', name: 'requirements', icon: <CheckCircle className="w-4 h-4" /> },
+    ];
+
+    const benefitFields = [
+        { title: '우대 사항', id: 'preferred', name: 'preferred', icon: <Gift className="w-4 h-4" /> },
+        { title: '혜택 및 복지', id: 'benefits', name: 'benefits', icon: <Gift className="w-4 h-4" /> },
+        { title: '지원 방법 및 절차', id: 'application', name: 'application', icon: <Mail className="w-4 h-4" /> },
+    ];
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        // 폼 제출 로직
+    };
+
+    const handleReset = () => {
+        setInputValue('');
+        setTextAreaValue('');
+    };
+
     return (
-        <form>
-            <InputTag
-                title="내용 작성"
-                type="text"
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                classMethod="w-full"
-                id=""
-                name=""
-            />
-            <TextArea
-                value={textAreaValue}
-                onChange={(e) => setTextAreaValue(e.target.value)}
-                classMethod="w-full"
-                id=""
-                name=""
-                cols={30}
-                rows={10}/>
-        </form>
+        <div className="form-container">
+            <div className="form-header">
+                <div className="form-header-icon">
+                    <BotMessageSquare className="w-6 h-6" />
+                </div>
+                <div>
+                    <h2 className="form-title">AI 챗봇과 채용 공고 작성</h2>
+                    <p className="form-description">
+                        단계별로 정보를 입력하시면 AI가 최적화된 채용 공고를 생성해드립니다.
+                    </p>
+                </div>
+            </div>
+
+            <form onSubmit={handleSubmit} className="form-content">
+                {/* 기본 정보 섹션 */}
+                <div className="form-section">
+                    <div className="section-header">
+                        <h3 className="section-title">
+                            <Building className="w-5 h-5" />
+                            기본 정보
+                        </h3>
+                        <p className="section-description">
+                            회사와 채용 포지션에 대한 기본 정보를 입력해주세요.
+                        </p>
+                    </div>
+
+                    <div className="form-fields-container">
+                        {basicInfoFields.map((input, index) => (
+                            <div key={input.id} className="form-field-item">
+                                <InputTag
+                                    title={input.title}
+                                    type="text"
+                                    value={inputValue}
+                                    onChange={(e) => setInputValue(e.target.value)}
+                                    classMethod=""
+                                    id={input.id}
+                                    name={input.name}
+                                />
+                                {index < basicInfoFields.length - 1 && <div className="field-divider" />}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 직무 정보 섹션 */}
+                <div className="form-section">
+                    <div className="section-header">
+                        <h3 className="section-title">
+                            <User className="w-5 h-5" />
+                            직무 상세 정보
+                        </h3>
+                        <p className="section-description">
+                            담당할 업무와 필요한 자격 요건을 자세히 입력해주세요.
+                        </p>
+                    </div>
+
+                    <div className="form-fields-container">
+                        {jobInfoFields.map((input, index) => (
+                            <div key={input.id} className="form-field-item">
+                                <InputTag
+                                    title={input.title}
+                                    type="text"
+                                    value={inputValue}
+                                    onChange={(e) => setInputValue(e.target.value)}
+                                    classMethod=""
+                                    id={input.id}
+                                    name={input.name}
+                                />
+                                {index < jobInfoFields.length - 1 && <div className="field-divider" />}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 혜택 및 지원 정보 섹션 */}
+                <div className="form-section">
+                    <div className="section-header">
+                        <h3 className="section-title">
+                            <Gift className="w-5 h-5" />
+                            혜택 및 지원 정보
+                        </h3>
+                        <p className="section-description">
+                            우대 사항, 복지 혜택, 지원 방법을 입력해주세요.
+                        </p>
+                    </div>
+
+                    <div className="form-fields-container">
+                        {benefitFields.map((input, index) => (
+                            <div key={input.id} className="form-field-item">
+                                <InputTag
+                                    title={input.title}
+                                    type="text"
+                                    value={inputValue}
+                                    onChange={(e) => setInputValue(e.target.value)}
+                                    classMethod=""
+                                    id={input.id}
+                                    name={input.name}
+                                />
+                                {index < benefitFields.length - 1 && <div className="field-divider" />}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 추가 정보 섹션 */}
+                <div className="form-section">
+                    <div className="section-header">
+                        <h3 className="section-title">
+                            <BotMessageSquare className="w-5 h-5" />
+                            AI에게 전하고 싶은 추가 정보
+                        </h3>
+                        <p className="section-description">
+                            특별히 강조하고 싶은 내용이나 추가 요구사항을 자유롭게 작성해주세요.
+                        </p>
+                    </div>
+
+                    <div className="textarea-full-container">
+                        <textarea
+                            value={textAreaValue}
+                            onChange={(e) => setTextAreaValue(e.target.value)}
+                            className="textarea-field-full"
+                            id="details"
+                            name="details"
+                            cols={30}
+                            rows={6}
+                            placeholder="예: 스타트업 환경에서 빠른 성장을 원하는 분, 리모트 근무 가능, 주니어도 환영 등..."
+                        />
+                    </div>
+                </div>
+
+                <div className="form-actions">
+                    <button
+                        type="button"
+                        onClick={handleReset}
+                        className="btn-reset"
+                    >
+                        <RotateCcw className="w-4 h-4" />
+                        초기화
+                    </button>
+                    <button
+                        type="submit"
+                        className="btn-submit"
+                    >
+                        <Send className="w-4 h-4" />
+                        AI 공고 생성하기
+                    </button>
+                </div>
+            </form>
+        </div>
     )
 }

--- a/src/app/components/chatFormComponents/types/inputType.ts
+++ b/src/app/components/chatFormComponents/types/inputType.ts
@@ -3,7 +3,7 @@ import {ChangeEvent} from "react";
 /**
  * InputType
  *
- * @param title Input labels 제목
+ * @param title Input label 제목
  * @param type Input 속성중 글,파일,숫자,등을 지정
  * @param value Input 속성중 입력 값을 지정
  * @param onChange Input 값 변경 핸들러
@@ -26,6 +26,7 @@ export type InputType = {
 /**
  * TextArea
  *
+ * @param title TextArea label 제목
  * @param value TextArea 속성중 입력 값을 지정
  * @param onChange TextArea 값 변경 핸들러
  * @param classMethod TextArea class 값을 지정
@@ -36,6 +37,7 @@ export type InputType = {
  *
  */
 export type TextAreaType = {
+    title: string,
     value: string,
     onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void,
     classMethod: string,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,14 @@
-/* ✅ Tailwind v4 방식 */
 @import "tailwindcss";
-
-/* ❌ Tailwind v3 방식 (오류 발생) */
-/*@tailwind base;
-@tailwind components;*/
-/*@tailwind utilities;*/
-
 
 @layer base {
   :root {
-    /* Theme (Light Mode) */
+    /* Theme (Light Mode) - 더 부드럽고 우아한 색상 */
     --background: 100% 0 0;
-    --foreground: 20% 0.01 250;
+    --foreground: 15% 0.01 250;
     --card: 98% 0 0;
-    --border: 90% 0 0;
-    --foreground-muted-l: 40%;
-    --foreground-muted-c: 0.01;
+    --border: 92% 0.005 250;
+    --foreground-muted-l: 45%;
+    --foreground-muted-c: 0.005;
     --foreground-muted-h: 250;
 
     /* Variables */
@@ -24,26 +17,25 @@
     --radius-lg: 12px;
     --radius-full: 9999px;
 
-    --shadow-sm: 0 1px 2px 0 oklch(0% 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px oklch(0% 0 0 / 0.1), 0 2px 4px -2px oklch(0% 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px oklch(0% 0 0 / 0.1), 0 4px 6px -4px oklch(0% 0 0 / 0.1);
+    --shadow-sm: 0 1px 2px 0 oklch(0% 0 0 / 0.03);
+    --shadow-md: 0 4px 6px -1px oklch(0% 0 0 / 0.05), 0 2px 4px -2px oklch(0% 0 0 / 0.03);
+    --shadow-lg: 0 10px 15px -3px oklch(0% 0 0 / 0.08), 0 4px 6px -4px oklch(0% 0 0 / 0.05);
   }
 
   .dark {
     /* Theme (Dark Mode) */
-    --background: 15% 0.01 250;
+    --background: 12% 0.01 250;
     --foreground: 98% 0 0;
-    --card: 20% 0.01 250;
-    --border: 30% 0.01 250;
-    --foreground-muted-l: 70%;
-    --foreground-muted-c: 0;
-    --foreground-muted-h: 0;
+    --card: 16% 0.01 250;
+    --border: 24% 0.01 250;
+    --foreground-muted-l: 65%;
+    --foreground-muted-c: 0.005;
+    --foreground-muted-h: 250;
   }
 }
 
-/* Tailwind v4 디자인 토큰 정의: 커스텀 유틸리티 생성의 기준 */
 @theme {
-  /* Colors (bg-*, text-*, border-*) */
+  /* Colors */
   --color-background: oklch(var(--background));
   --color-foreground: oklch(var(--foreground));
   --color-card: oklch(var(--card));
@@ -51,9 +43,9 @@
   --color-foreground-muted: oklch(var(--foreground-muted-l) var(--foreground-muted-c) var(--foreground-muted-h));
 
   /* Typography */
-  --font-sans: var(--font-sans);
-  --font-serif: var(--font-serif);
-  --font-mono: var(--font-mono);
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
+  --font-serif: ui-serif, Georgia, serif;
+  --font-mono: ui-monospace, SFMono-Regular, monospace;
 
   --text-hero: clamp(2rem, 5vw, 2.75rem);
   --text-h1: 1.75rem;
@@ -61,7 +53,7 @@
   --text-body: 1rem;
   --text-caption: 0.875rem;
 
-  /* Radius & Shadow (선택적으로 커스터마이즈) */
+  /* Radius & Shadow */
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);
   --radius-lg: var(--radius-lg);
@@ -72,9 +64,65 @@
   --shadow-lg: var(--shadow-lg);
 }
 
-/* 전역 기본 스타일 */
 @layer base {
+  * {
+    @apply border-border;
+  }
+
   body {
-    @apply bg-background text-foreground text-body font-sans;
+    @apply bg-background text-foreground font-sans antialiased;
+    font-size: 16px;
+    line-height: 1.6;
+  }
+
+  /* 부드러운 스크롤 */
+  html {
+    scroll-behavior: smooth;
+  }
+
+  /* 선택 텍스트 스타일 */
+  ::selection {
+    background-color: oklch(var(--foreground) / 0.1);
+  }
+}
+
+@layer utilities {
+  /* 사용자 정의 애니메이션 */
+  .animate-fade-in {
+    animation: fadeIn 0.6s ease-out forwards;
+  }
+
+  .animate-slide-up {
+    animation: slideUp 0.6s ease-out forwards;
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes slideUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* 포커스 스타일 개선 */
+  .focus-ring {
+    @apply focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:ring-offset-2 focus:ring-offset-background;
+  }
+
+  /* 호버 효과 */
+  .hover-lift {
+    @apply transition-transform duration-200 hover:translate-y-[-2px];
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,18 @@
-'use client'; // 이 줄을 추가
+'use client';
 
-import {BotMessageSquare, Briefcase, CheckCircle, Sparkles} from 'lucide-react';
-import './globals.css';
-import Image from 'next/image'
+import {ArrowRight, BotMessageSquare, CheckCircle, Clock, Sparkles, Target, Zap} from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
 
-// 페이지 전체를 감싸는 메인 컴포넌트
 export default function LandingPage() {
     return (
-        <div className="flex flex-col min-h-screen bg-background items-center justify-center">
+        <div className="min-h-screen bg-background text-foreground">
             <Header />
-            <main className="flex-grow">
+            <main>
                 <HeroSection />
                 <FeaturesSection />
                 <HowItWorksSection />
+                <BenefitsSection />
                 <CtaSection />
             </main>
             <Footer />
@@ -20,129 +20,87 @@ export default function LandingPage() {
     );
 }
 
-// 헤더 컴포넌트
 function Header() {
     return (
-        <header className="container py-4">
-            <nav className="flex items-center justify-between">
-                <a href="#" className="flex items-center gap-2 font-bold text-h2">
-                    <Briefcase className="w-6 h-6" />
-                    <span>AutoJD</span>
-                </a>
-                <a
-                    href="#"
-                    className="px-4 py-2 text-sm font-semibold transition-colors rounded-full bg-foreground text-background hover:bg-opacity-80"
-                >
-                    지금 시작하기
-                </a>
-            </nav>
+        <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-sm border-b border-border">
+            <div className="container mx-auto px-6 py-4">
+                <nav className="flex items-center justify-between">
+                    <Link href="/" className="flex items-center gap-2 text-h2 font-sans font-bold">
+                        <div className="p-2 bg-card rounded-md shadow-sm">
+                            <BotMessageSquare className="w-5 h-5 text-foreground" />
+                        </div>
+                        <span>ChatJD</span>
+                    </Link>
+                    <div className="flex items-center gap-6">
+                        <div className="hidden md:flex items-center gap-6">
+                            <Link href="#features" className="text-body text-foreground-muted hover:text-foreground transition-colors">
+                                기능
+                            </Link>
+                            <Link href="#how-it-works" className="text-body text-foreground-muted hover:text-foreground transition-colors">
+                                사용법
+                            </Link>
+                        </div>
+                    </div>
+                    <Link
+                        href="/chatForm"
+                        className="px-4 py-2 bg-foreground text-background rounded-lg text-body font-semibold hover:opacity-90 transition-opacity"
+                    >
+                        시작하기
+                    </Link>
+                </nav>
+            </div>
         </header>
-    );
+);
 }
 
-// 히어로 섹션
 function HeroSection() {
     return (
-        <section className="py-16 text-center md:py-24">
-            <div className="container">
-                <h1 className="text-hero">
-                    AI 챗봇으로 채용 공고 작성을 자동화한다
-                </h1>
-                <p className="max-w-2xl mx-auto mt-4 text-lg text-foreground-muted">
-                    단 몇 분 만에 최고의 인재를 끌어당기는 매력적인 채용 공고가 완성된다. 반복적인 업무는 줄이고 핵심에 집중하게 된다.
-                </p>
-                <div className="mt-8">
-                    <a
-                        href="#"
-                        className="px-8 py-3 font-bold transition-transform duration-300 transform rounded-full shadow-lg bg-foreground text-background hover:scale-105"
-                    >
-                        무료로 채용 공고 만들기
-                    </a>
-                </div>
-                {/* --- 이미지 추가 --- */}
-                <div className="mt-12 md:mt-16">
-                    <Image
-                        src="https://placehold.co/900x500/1a202c/ffffff?text=AI+Chatbot+UI"
-                        alt="AI 챗봇 인터페이스 예시"
-                        className="w-full max-w-4xl mx-auto border rounded-lg shadow-lg border-border"
-                        width={900}
-                        height={500}
-                        onError={(e) => { e.currentTarget.src = 'https://placehold.co/900x500/e2e8f0/4a5568?text=Image+Not+Found'; }}
-                    />
-                </div>
-            </div>
-        </section>
-    );
-}
+        <section className="py-20 md:py-32">
+            <div className="container mx-auto px-6">
+                <div className="max-w-4xl mx-auto text-center">
+                    <div className="inline-flex items-center gap-2 px-4 py-2 bg-card border border-border rounded-full text-caption text-foreground-muted mb-6">
+                        <Sparkles className="w-4 h-4" />
+                        AI 기반 채용 공고 생성 도구
+                    </div>
 
-// 기능 소개 섹션
-function FeaturesSection() {
-    const features = [
-        {
-            icon: <BotMessageSquare className="w-8 h-8 text-foreground" />,
-            title: "대화형 AI 기반 생성",
-            description: "챗봇과 대화하며 직무, 요구 기술, 기업 문화를 입력하면 AI가 맞춤형 공고를 생성한다.",
-        },
-        {
-            icon: <Sparkles className="w-8 h-8 text-foreground" />,
-            title: "매력적인 문구 자동 완성",
-            description: "지원자의 시선을 끄는 효과적인 헤드라인과 직무 설명을 제안하여 지원율을 높인다.",
-        },
-        {
-            icon: <CheckCircle className="w-8 h-8 text-foreground" />,
-            title: "일관성 있는 톤앤매너",
-            description: "여러 채용 공고에 일관된 목소리와 브랜딩을 적용하여 전문적인 기업 이미지를 구축한다.",
-        },
-    ];
+                    <h1 className="text-hero font-sans mb-6">
+                        <span className="block">AI 챗봇과 대화로</span>
+                        <span className="block text-foreground-muted">완벽한 채용 공고 완성</span>
+                    </h1>
 
-    return (
-        <section id="features" className="py-16 bg-card md:py-24">
-            <div className="container">
-                <div className="text-center">
-                    <h2 className="text-h1">왜 AutoJD를 선택해야 하는가?</h2>
-                    <p className="mt-2 text-foreground-muted">AutoJD는 단순한 자동화를 넘어 채용의 질을 높인다.</p>
-                </div>
-                <div className="grid gap-8 mt-12 md:grid-cols-3">
-                    {features.map((feature, index) => (
-                        <div key={index} className="p-6 text-center border rounded-lg bg-background border-border shadow-sm">
-                            <div className="inline-block p-3 mb-4 rounded-full bg-card">
-                                {feature.icon}
+                    <p className="text-body text-foreground-muted max-w-2xl mx-auto mb-8">
+                        복잡한 채용 공고 작성을 AI 챗봇이 도와드립니다.
+                        간단한 대화만으로 전문적이고 매력적인 채용 공고를 몇 분 안에 완성하세요.
+                    </p>
+
+                    <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12">
+                        <Link
+                            href="/chat-form"
+                            className="w-full sm:w-auto px-8 py-3 bg-foreground text-background rounded-lg text-body font-semibold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                        >
+                            무료로 시작하기
+                            <ArrowRight className="w-4 h-4" />
+                        </Link>
+                        <button className="w-full sm:w-auto px-8 py-3 bg-card border border-border text-foreground rounded-lg text-body font-semibold hover:bg-border/10 transition-colors">
+                            데모 보기
+                        </button>
+                    </div>
+
+                    <div className="relative max-w-4xl mx-auto">
+                        <div className="relative bg-card border border-border rounded-lg shadow-lg overflow-hidden">
+                            <div className="bg-border/20 px-4 py-2 flex items-center gap-2">
+                                <div className="w-3 h-3 bg-red-400 rounded-full"></div>
+                                <div className="w-3 h-3 bg-yellow-400 rounded-full"></div>
+                                <div className="w-3 h-3 bg-green-400 rounded-full"></div>
+                                <span className="text-caption text-foreground-muted ml-4">ChatJD - AI 채용 공고 생성기</span>
                             </div>
-                            <h3 className="mb-2 text-h2">{feature.title}</h3>
-                            <p className="text-caption text-foreground-muted">{feature.description}</p>
-                        </div>
-                    ))}
-                </div>
-                {/* --- 이미지 캐러셀 추가 --- */}
-                <div className="mt-16">
-                    <h3 className="mb-6 text-center text-h2">주요 기능 미리보기</h3>
-                    <div className="flex gap-4 pb-4 overflow-x-auto">
-                        <div className="flex-shrink-0 w-4/5 md:w-1/3">
                             <Image
-                                src="https://placehold.co/600x400/1a202c/ffffff?text=Feature+1"
-                                alt="기능 1"
-                                className="object-cover w-full border rounded-md aspect-video border-border"
-                                width={600}
-                                height={400}
-                                onError={(e) => { e.currentTarget.src = 'https://placehold.co/600x400/e2e8f0/4a5568?text=Image'; }} />
-                        </div>
-                        <div className="flex-shrink-0 w-4/5 md:w-1/3">
-                            <Image
-                                src="https://placehold.co/600x400/1a202c/ffffff?text=Feature+2"
-                                alt="기능 2"
-                                className="object-cover w-full border rounded-md aspect-video border-border"
-                                width={600}
-                                height={400}
-                                onError={(e) => { e.currentTarget.src = 'https://placehold.co/600x400/e2e8f0/4a5568?text=Image'; }} />
-                        </div>
-                        <div className="flex-shrink-0 w-4/5 md:w-1/3">
-                            <Image
-                                src="https://placehold.co/600x400/1a202c/ffffff?text=Feature+3"
-                                alt="기능 3"
-                                className="object-cover w-full border rounded-md aspect-video border-border"
-                                width={600}
-                                height={400}
-                                onError={(e) => { e.currentTarget.src = 'https://placehold.co/600x400/e2e8f0/4a5568?text=Image'; }}/>
+                                src="https://placehold.co/800x500/f8fafc/64748b?text=AI+Chat+Interface"
+                                alt="AI 챗봇 인터페이스"
+                                width={800}
+                                height={500}
+                                className="w-full h-auto"
+                            />
                         </div>
                     </div>
                 </div>
@@ -151,39 +109,46 @@ function FeaturesSection() {
     );
 }
 
-// 작동 방식 섹션
-function HowItWorksSection() {
-    const steps = [
+function FeaturesSection() {
+    const features = [
         {
-            title: "핵심 정보 입력",
-            description: "채용할 직무, 필수 요건, 주요 기술 스택 등 기본적인 정보를 챗봇에게 알려준다.",
-            imgSrc: "https://placehold.co/500x350/1a202c/ffffff?text=Step+1:+정보+입력",
-            align: "left"
+            icon: <BotMessageSquare className="w-6 h-6" />,
+            title: "대화형 AI 생성",
+            description: "챗봇과 자연스러운 대화를 통해 채용 요구사항을 파악하고 맞춤형 공고를 생성합니다.",
         },
         {
-            title: "AI 생성 및 검토",
-            description: "AI가 입력된 정보를 바탕으로 채용 공고 초안을 몇 초 만에 생성한다. 원하는 대로 수정하고 다듬을 수 있다.",
-            imgSrc: "https://placehold.co/500x350/1a202c/ffffff?text=Step+2:+AI+생성",
-            align: "right"
+            icon: <Zap className="w-6 h-6" />,
+            title: "빠른 생성 속도",
+            description: "기존 수시간 걸리던 작업을 몇 분 만에 완료할 수 있어 업무 효율성을 극대화합니다.",
         },
         {
-            title: "완성 및 게시",
-            description: "최종 완성된 공고를 복사하여 바로 채용 플랫폼에 게시한다. 시간을 획기적으로 절약할 수 있다.",
-            imgSrc: "https://placehold.co/500x350/1a202c/ffffff?text=Step+3:+완성+및+게시",
-            align: "left"
-        }
+            icon: <Target className="w-6 h-6" />,
+            title: "정확한 매칭",
+            description: "직무별 특성과 기업 문화를 반영하여 적합한 인재를 끌어들이는 공고를 작성합니다.",
+        },
     ];
 
     return (
-        <section className="py-16 md:py-24">
-            <div className="container">
-                <div className="text-center">
-                    <h2 className="text-h1">3단계로 끝나는 채용 공고 작성</h2>
-                    <p className="mt-2 text-foreground-muted">누구나 쉽게 사용할 수 있도록 설계되었다.</p>
+        <section id="features" className="py-20 bg-card">
+            <div className="container mx-auto px-6">
+                <div className="max-w-3xl mx-auto text-center mb-16">
+                    <h2 className="text-h1 font-sans mb-4">
+                        왜 ChatJD인가요?
+                    </h2>
+                    <p className="text-body text-foreground-muted">
+                        전문적인 채용 공고 작성이 이렇게 쉬워도 되나요?
+                    </p>
                 </div>
-                <div className="mt-12 space-y-16 md:mt-20">
-                    {steps.map((step, index) => (
-                        <Step key={index} title={step.title} description={step.description} imgSrc={step.imgSrc} align={step.align}  />
+
+                <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+                    {features.map((feature, index) => (
+                        <div key={index} className="bg-background border border-border rounded-lg p-6 text-center hover:shadow-md transition-shadow">
+                            <div className="inline-flex items-center justify-center w-12 h-12 bg-card border border-border rounded-lg mb-4">
+                                {feature.icon}
+                            </div>
+                            <h3 className="text-h2 font-sans mb-3">{feature.title}</h3>
+                            <p className="text-caption text-foreground-muted">{feature.description}</p>
+                        </div>
                     ))}
                 </div>
             </div>
@@ -191,72 +156,131 @@ function HowItWorksSection() {
     );
 }
 
-// 작동 방식 각 단계를 나타내는 컴포넌트 (이미지 포함)
-/**
- * @param {{
- * title: string;
- * description: string;
- * imgSrc: string;
- * align: string;
- * }} props
- */
-function Step({ title, description, imgSrc, align }: {
-        title: string;
-        description: string;
-        imgSrc: string;
-        align: string;
-    }) {
-    const isRightAlign = align === 'right';
-    return (
-        <div className={`flex flex-col md:flex-row items-center gap-8 md:gap-12 ${isRightAlign ? 'md:flex-row-reverse' : ''}`}>
-            <div className="w-full md:w-1/2">
-                <Image
-                    src={imgSrc}
-                    alt={title}
-                    className="w-full border rounded-lg shadow-md border-border"
-                    width={500}
-                    height={350}
-                    onError={(e) => { e.currentTarget.src = 'https://placehold.co/500x350/e2e8f0/4a5568?text=Image+Not+Found'; }}
-                />
-            </div>
-            <div className="w-full text-center md:w-1/2 md:text-left">
-                <h3 className="text-h2">{title}</h3>
-                <p className="mt-2 text-foreground-muted">{description}</p>
-            </div>
-        </div>
-    );
-}
+function HowItWorksSection() {
+    const steps = [
+        {
+            title: "기본 정보 입력",
+            description: "채용하려는 직무, 필요한 기술, 경력 수준 등을 챗봇에게 알려주세요.",
+            imgSrc: "https://placehold.co/600x400/f8fafc/64748b?text=Step+1",
+        },
+        {
+            title: "AI 분석 및 생성",
+            description: "AI가 입력된 정보를 분석하여 최적화된 채용 공고를 자동으로 생성합니다.",
+            imgSrc: "https://placehold.co/600x400/f8fafc/64748b?text=Step+2",
+        },
+        {
+            title: "검토 및 완성",
+            description: "생성된 공고를 검토하고 필요시 수정하여 완벽한 채용 공고를 완성합니다.",
+            imgSrc: "https://placehold.co/600x400/f8fafc/64748b?text=Step+3",
+        },
+    ];
 
-
-// 최종 CTA 섹션
-function CtaSection() {
     return (
-        <section className="py-16 text-center md:py-24 bg-card">
-            <div className="container">
-                <h2 className="text-h1">이제, 채용 공고 작성의 미래를 경험할 시간이다.</h2>
-                <p className="max-w-2xl mx-auto mt-4 text-foreground-muted">
-                    지금 바로 시작해서 채용 프로세스의 효율을 극대화해야 한다.
-                </p>
-                <div className="mt-8">
-                    <a
-                        href="#"
-                        className="px-8 py-3 font-bold transition-transform duration-300 transform rounded-full shadow-lg bg-foreground text-background hover:scale-105"
-                    >
-                        첫 공고 무료로 생성하기
-                    </a>
+        <section id="how-it-works" className="py-20">
+            <div className="container mx-auto px-6">
+                <div className="max-w-3xl mx-auto text-center mb-16">
+                    <h2 className="text-h1 font-sans mb-4">
+                        3단계로 완성하는 채용 공고
+                    </h2>
+                    <p className="text-body text-foreground-muted">
+                        복잡한 과정 없이 누구나 쉽게 전문적인 채용 공고를 만들 수 있습니다.
+                    </p>
+                </div>
+
+                <div className="max-w-4xl mx-auto">
+                    {steps.map((step, index) => (
+                        <div key={index} className={`flex flex-col ${index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'} items-center gap-12 mb-20 last:mb-0`}>
+                            <div className="flex-1">
+                                <div className="bg-card border border-border rounded-lg overflow-hidden shadow-sm">
+                                    <Image
+                                        src={step.imgSrc}
+                                        alt={step.title}
+                                        width={600}
+                                        height={400}
+                                        className="w-full h-auto"
+                                    />
+                                </div>
+                            </div>
+                            <div className="flex-1 text-center md:text-left">
+                                <div className="inline-flex items-center justify-center w-8 h-8 bg-foreground text-background rounded-full text-caption font-bold mb-4">
+                                    {index + 1}
+                                </div>
+                                <h3 className="text-h2 font-sans mb-3">{step.title}</h3>
+                                <p className="text-body text-foreground-muted">{step.description}</p>
+                            </div>
+                        </div>
+                    ))}
                 </div>
             </div>
         </section>
     );
 }
 
-// 푸터 컴포넌트
+function BenefitsSection() {
+    const benefits = [
+        { icon: <Clock className="w-5 h-5" />, text: "작업 시간 90% 단축" },
+        { icon: <CheckCircle className="w-5 h-5" />, text: "전문적인 공고 품질" },
+        { icon: <Target className="w-5 h-5" />, text: "높은 지원자 만족도" },
+    ];
+
+    return (
+        <section className="py-16 bg-card">
+            <div className="container mx-auto px-6">
+                <div className="max-w-4xl mx-auto bg-background border border-border rounded-lg p-8 text-center">
+                    <h3 className="text-h2 font-sans mb-6">실제 사용자들의 성과</h3>
+                    <div className="grid md:grid-cols-3 gap-6">
+                        {benefits.map((benefit, index) => (
+                            <div key={index} className="flex items-center justify-center gap-2 text-body">
+                                {benefit.icon}
+                                <span>{benefit.text}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+function CtaSection() {
+    return (
+        <section className="py-20">
+            <div className="container mx-auto px-6">
+                <div className="max-w-3xl mx-auto text-center">
+                    <h2 className="text-h1 font-sans mb-4">
+                        지금 바로 시작해보세요
+                    </h2>
+                    <p className="text-body text-foreground-muted mb-8">
+                        몇 분만 투자하여 완벽한 채용 공고를 만들어보세요.
+                        가입이나 결제 없이 바로 이용 가능합니다.
+                    </p>
+                    <Link
+                        href="/chat-form"
+                        className="inline-flex items-center gap-2 px-8 py-3 bg-foreground text-background rounded-lg text-body font-semibold hover:opacity-90 transition-opacity"
+                    >
+                        무료로 채용 공고 만들기
+                        <ArrowRight className="w-4 h-4" />
+                    </Link>
+                </div>
+            </div>
+        </section>
+    );
+}
+
 function Footer() {
     return (
-        <footer className="py-8 border-t border-border">
-            <div className="container text-center text-caption text-foreground-muted">
-                <p>&copy; {new Date().getFullYear()} AutoJD. All rights reserved.</p>
-                <p className="mt-2">개발자: 남상도</p>
+        <footer className="py-12 bg-card border-t border-border">
+            <div className="container mx-auto px-6">
+                <div className="flex flex-col md:flex-row items-center justify-between">
+                    <div className="flex items-center gap-2 mb-4 md:mb-0">
+                        <BotMessageSquare className="w-5 h-5" />
+                        <span className="text-h2 font-sans font-bold">ChatJD</span>
+                    </div>
+                    <div className="text-caption text-foreground-muted text-center md:text-right">
+                        <p>&copy; {new Date().getFullYear()} ChatJD. All rights reserved.</p>
+                        <p className="mt-1">AI 기반 채용 공고 생성 도구</p>
+                    </div>
+                </div>
             </div>
         </footer>
     );


### PR DESCRIPTION
AI 기반 채용 공고 작성 기능을 개선하기 위해 채용 공고 생성 페이지와 관련 컴포넌트를 리팩토링 및 확장했습니다.

- `page.tsx`: UI 개편 및 홈 이동 링크, 섹션 헤더 추가
- `form.tsx`: 폼 구조 리팩토링 및 섹션별 필드 분리, 초기화/제출 버튼 추가
- `InputTag`, `TextArea`: 가독성을 위한 필드 스타일 개선 및 placeholder 추가
- `globals.css`: 디자인 개선을 위한 색상, 그림자, 폰트, 유틸리티 클래스 업데이트
- 타입 정의(`inputType.ts`): `title` 필드 추가 및 주석 보강
- 기타: 새로운 SVG 및 애니메이션 적용

사용자 친화적 인터페이스와 기능으로 작업 효율성을 대폭 향상시켰습니다.