### PR TITLE
feat(config): basePath 및 정적 사이트 빌드 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type {NextConfig} from "next";
 
+const repoName = 'jobmoa_Automatically_generate_jobPostings';
+
 const nextConfig: NextConfig = {
   /* config options here */
+    // 1. basePath 추가: 저장소 이름을 값으로 설정
+    basePath: `/${repoName}`,
+
+    // 2. output: 'export' 추가: 정적 사이트 빌드를 명시
+    output: 'export',
+
     images: {
         // 외부 이미지 호스트 허용 설정
         remotePatterns: [


### PR DESCRIPTION
Next.js 애플리케이션의 배포 환경에 최적화된 설정을 추가했습니다.

- `basePath`: 저장소 이름(`/jobmoa_Automatically_generate_jobPostings`)으로 설정하여 경로 관리 개선
- `output: export`: 정적 사이트 빌드(export) 옵션 활성화

이는 정적 리소스 경로 관리 및 호환성을 개선하기 위한 변경입니다.