### PR TITLE
fix(chatForm): 페이지 리다이렉트 경로 수정

### DIFF
--- a/src/app/components/chatFormComponents/form.tsx
+++ b/src/app/components/chatFormComponents/form.tsx
@@ -119,7 +119,7 @@ export default function FormPage(){
             textAreaValue
         });
         //페이지 이동
-        window.location.href = '/test.html';
+        window.location.href = '/jobmoa_Automatically_generate_jobPostings/test.html';
     };
 
     const handleReset = () => {


### PR DESCRIPTION
정적 사이트 배포 설정(`basePath`) 변경으로 인해, 폼 제출 후 리다이렉트 경로를 `/test.html`에서 `/jobmoa_Automatically_generate_jobPostings/test.html`로 업데이트했습니다.

이는 올바른 이동 경로를 보장하기 위한 수정입니다.